### PR TITLE
Update to cl-lib

### DIFF
--- a/fira-code.el
+++ b/fira-code.el
@@ -9,7 +9,7 @@
 (require 'ligature-font)
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 (require 'dash)
 
 (load "fira-code-data")

--- a/ligature-font.el
+++ b/ligature-font.el
@@ -10,7 +10,7 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 (require 'dash)
 
 (defvar-local ligature-font-char-list nil)
@@ -76,7 +76,7 @@ replaced with a glyph while `ligature-font-mode' is active.  See also
         ("$" t)                         ; use alternate $
         ("/=" "!=")                     ; "not equal" is /=
         ("!=" nil)                      ; != is not special
-        (t default-enabled)))
+        (_ default-enabled)))
      (t default-enabled))))
 
 (defun ligature-font--default-compose-predicate


### PR DESCRIPTION
`cl` is deprecated in favor of `cl-lib` which seems to be replaceable on the stop (byte-compiling the files succeeds).

Also there is a complain about `Pattern t is deprecated, use _` so I changed also that.